### PR TITLE
Update FacebookManager.cs

### DIFF
--- a/Scripts/Facebook/Components/FacebookManager.cs
+++ b/Scripts/Facebook/Components/FacebookManager.cs
@@ -751,8 +751,8 @@ namespace GameFramework.Facebook.Components
                     resultType = FacebookAppRequestMessage.ResultType.OK;
                     HasInvitedFriends = true;
 
-                    JSONValue to = jsonObject.GetArray("to");
-                    if (to != null || to.Type == JSONValueType.Array)
+                    JSONValue to = jsonObject.GetValue("to");
+                    if (to != null && to.Type == JSONValueType.Array)
                     {
                         NumberOfInvitesSent += to.Array.Length;
                         foreach (JSONValue value in to.Array)
@@ -760,6 +760,10 @@ namespace GameFramework.Facebook.Components
                             InvitedFriends.Add(value.Str);
                             Debug.Log("Value: " + value.Str);
                         }
+                    }else if (to != null && to.Type == JSONValueType.String)
+                    {
+                        InvitedFriends.Add(to.Str);
+                        Debug.Log("Value: " + value.Str);
                     }
                 }
             }


### PR DESCRIPTION
If you only send one app request the "to" value in the returned JSON is a string not an array of one. This change corrects a reference not set to an instance of an object exception in that instance.

You get this from Facebook 
{"to":"1534995506528760","request":"655925497912303","callback_id":"4"}

but the code was expecting
{"to":["1534995506528760"],"request":"655925497912303","callback_id":"4"}